### PR TITLE
Fix order item fetch

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -157,14 +157,15 @@ async function getOrderItemById(orderItemId: string): Promise<OrderItem> {
     )
 
     if (response.ok) {
-      if (response.status === 201) {
+      if (response.status === 200) {
         const data: OrderItem = await response.json()
         return data
       }
-      return {} as OrderItem;
+      return {} as OrderItem
     } else {
-      throw new Error('Failed to fetch order item');
-    }}
+      throw new Error('Failed to fetch order item')
+    }
+}
 
 
 


### PR DESCRIPTION
## Summary
- fix incorrect status check when fetching a single order item

## Testing
- `npm run typecheck` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68457ad5f02083258c4f489aae94aac2