### PR TITLE
Implement pagination for product requests

### DIFF
--- a/src/app/(dashboard)/products/page.tsx
+++ b/src/app/(dashboard)/products/page.tsx
@@ -7,10 +7,10 @@ export const metadata = {
 };
 
 // Fetch products from the API
-async function getProducts(): Promise<Product[]> {
+async function getProducts(page: number, limit: number): Promise<Product[]> {
   const { getProducts: fetchProducts } = handlesAPIProducts();
   try {
-    const data: Product[] = await fetchProducts();
+    const data: Product[] = await fetchProducts(page, limit);
     return data;
   } catch (error) {
     console.error('Error fetching products:', error);
@@ -18,9 +18,22 @@ async function getProducts(): Promise<Product[]> {
   }
 }
 
-export default async function ProductsPage() {
-  const allProducts = await getProducts();
-  const itemsPerPage = 6;
+interface ProductsPageProps {
+  searchParams?: {
+    page?: string;
+    limit?: string;
+  };
+}
 
-  return <ProductsClient products={allProducts} itemsPerPage={itemsPerPage} />;
+export default async function ProductsPage({
+  searchParams,
+}: ProductsPageProps) {
+  const page = parseInt(searchParams?.page || '1', 10);
+  const limit = parseInt(searchParams?.limit || '6', 10);
+
+  const allProducts = await getProducts(page, limit);
+
+  return (
+    <ProductsClient products={allProducts} itemsPerPage={limit} />
+  );
 }

--- a/src/lib/api_products.ts
+++ b/src/lib/api_products.ts
@@ -3,8 +3,15 @@ import { Product } from "./types";
 
 const { url_api } = getGlobalUrls();
 
-async function getProducts(): Promise<Product[]> {
-    const url = `${url_api}/api/products`;
+async function getProducts(page?: number, limit?: number): Promise<Product[]> {
+    let url = `${url_api}/api/products`;
+    const params = new URLSearchParams();
+    if (page !== undefined) params.set('page', String(page));
+    if (limit !== undefined) params.set('limit', String(limit));
+    const query = params.toString();
+    if (query) {
+        url = `${url}?${query}`;
+    }
 
     const response = await fetch(url, {
         method: "GET",


### PR DESCRIPTION
## Summary
- allow pagination parameters in `getProducts`
- parse searchParams in `ProductsPage` to request paginated products

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684586827e788325aae4f1bb890f70d7