### PR TITLE
Fix products API response handling

### DIFF
--- a/src/app/(dashboard)/products/page.tsx
+++ b/src/app/(dashboard)/products/page.tsx
@@ -1,4 +1,4 @@
-import type { Product } from '@/lib/types';
+import type { Product, ProductsResponse } from '@/lib/types';
 import { handlesAPIProducts } from '@/lib/api_products';
 import ProductsClient from '@/components/products/ProductsClient';
 
@@ -7,14 +7,14 @@ export const metadata = {
 };
 
 // Fetch products from the API
-async function getProducts(page: number, limit: number): Promise<Product[]> {
+async function getProducts(page: number, limit: number): Promise<ProductsResponse> {
   const { getProducts: fetchProducts } = handlesAPIProducts();
   try {
-    const data: Product[] = await fetchProducts(page, limit);
+    const data: ProductsResponse = await fetchProducts(page, limit);
     return data;
   } catch (error) {
     console.error('Error fetching products:', error);
-    return [];
+    return { data: [], total: 0, page: '0', per_page: '0' };
   }
 }
 
@@ -31,9 +31,10 @@ export default async function ProductsPage({
   const page = parseInt(searchParams?.page || '0', 10);
   const limit = parseInt(searchParams?.limit || '6', 10);
 
-  const allProducts = await getProducts(page, limit);
+  const apiResponse = await getProducts(page, limit);
+  const itemsPerPage = parseInt(apiResponse.per_page, 10) || limit;
 
   return (
-    <ProductsClient products={allProducts} itemsPerPage={limit} />
+    <ProductsClient products={apiResponse.data} itemsPerPage={itemsPerPage} />
   );
 }

--- a/src/lib/api_products.ts
+++ b/src/lib/api_products.ts
@@ -1,9 +1,9 @@
 import { getGlobalUrls } from "./configs";
-import { Product } from "./types";
+import { Product, ProductsResponse } from "./types";
 
 const { url_api } = getGlobalUrls();
 
-async function getProducts(page?: number, limit?: number): Promise<Product[]> {
+async function getProducts(page?: number, limit?: number): Promise<ProductsResponse> {
     let url = `${url_api}/api/products`;
     const params = new URLSearchParams();
     if (page !== undefined) params.set('page', String(page));
@@ -20,10 +20,11 @@ async function getProducts(page?: number, limit?: number): Promise<Product[]> {
 
     if (response.ok) {
         if (response.status === 200) {
-            const data: Product[] = await response.json();
+            const data: ProductsResponse = await response.json();
             return data;
         }
-        return [];
+        // Default empty structure if response is not 200
+        return { data: [], total: 0, page: "0", per_page: "0" };
     } else {
         throw new Error('Failed to fetch products');
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,3 +43,11 @@ export interface ResponseAPI {
   message: string;
   data?: any; // Use 'any' for flexibility, or define a more specific type if needed
 }
+
+// Represents the paginated product list returned by the API
+export interface ProductsResponse {
+  data: Product[];
+  total: number;
+  page: string;     // current page as a string
+  per_page: string; // items per page as a string
+}


### PR DESCRIPTION
## Summary
- add `ProductsResponse` type for API response
- update API client to return `ProductsResponse`
- update products page to use the new response structure

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684596d3a92083258f24aad027f1195e