### PR TITLE
Fix create order endpoint

### DIFF
--- a/src/app/(dashboard)/orders/page.tsx
+++ b/src/app/(dashboard)/orders/page.tsx
@@ -1,0 +1,24 @@
+import OrdersClient from '@/components/orders/OrdersClient';
+import { getHandlesAPI } from '@/lib/api';
+import type { Order, Table } from '@/lib/types';
+
+export const metadata = {
+  title: 'Orders - MesaFacil',
+};
+
+async function getActiveOrders(): Promise<{orders: Order[]; tables: Table[]}> {
+  const { getTables, getOrders } = getHandlesAPI();
+  const tables = await getTables();
+  const ordersLists = await Promise.all(
+    tables.map((t) => getOrders(t.id_table))
+  );
+  const orders = ordersLists
+    .flat()
+    .filter((o) => o.status === 'Pendente' || o.status === 'Preparando');
+  return { orders, tables };
+}
+
+export default async function OrdersPage() {
+  const { orders, tables } = await getActiveOrders();
+  return <OrdersClient orders={orders} tables={tables} />;
+}

--- a/src/components/orders/OrdersClient.tsx
+++ b/src/components/orders/OrdersClient.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import { PageHeader } from '@/components/layout/PageHeader';
+import { OrderSummaryCard } from './OrderSummaryCard';
+import type { Order, Table, CreateOrder } from '@/lib/types';
+import { Dialog, DialogTrigger, DialogContent } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { PlusCircle } from 'lucide-react';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { getHandlesAPI } from '@/lib/api';
+
+interface OrdersClientProps {
+  orders: Order[];
+  tables: Table[];
+}
+
+const formSchema = z.object({
+  id_table: z.string().min(1),
+  quantity: z.number().min(1),
+});
+
+export default function OrdersClient({ orders, tables }: OrdersClientProps) {
+  const { createOrder } = getHandlesAPI();
+  const [open, setOpen] = useState(false);
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      id_table: tables[0]?.id_table ?? '',
+      quantity: 1,
+    },
+  });
+
+  const onSubmit = async (data: z.infer<typeof formSchema>) => {
+    const payload: CreateOrder = {
+      id_table: data.id_table,
+      quantity: data.quantity,
+    };
+    await createOrder(payload);
+    setOpen(false);
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <PageHeader
+        title="Active Orders"
+        description="List of orders currently in progress."
+        actions={
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <Button>
+                <PlusCircle className="mr-2 h-4 w-4" /> New Order
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                  <FormField
+                    control={form.control}
+                    name="id_table"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Table</FormLabel>
+                        <Select value={field.value} onValueChange={field.onChange}>
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select table" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {tables.map((table) => (
+                              <SelectItem key={table.id_table} value={table.id_table}>
+                                {`Mesa ${table.table_number} - ${table.location}`}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="quantity"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Quantity</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            {...field}
+                            onChange={(e) => field.onChange(parseInt(e.target.value, 10))}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <Button type="submit">Create Order</Button>
+                </form>
+              </Form>
+            </DialogContent>
+          </Dialog>
+        }
+      />
+
+      {orders.length === 0 ? (
+        <p className="text-muted-foreground">No active orders.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {orders.map((order) => (
+            <OrderSummaryCard key={order.id_order} order={order} />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,6 @@
 // lib/config.ts
 import { getGlobalUrls } from "./configs";
-import type { Table, Order, OrderItem, ResponseAPI } from "./types";
+import type { Table, Order, OrderItem, ResponseAPI, CreateOrder } from "./types";
 
 const {url_api} = getGlobalUrls();
 
@@ -47,7 +47,7 @@ async function getTableById(tableId: string): Promise<Table> {
 
 async function createTable(table: Table): Promise<ResponseAPI> {
   try {
-    const response = await fetch(`http://localhost:8080/api/create-table`, {
+    const response = await fetch(`${url_api}/api/create-table`, {
       method: "POST",
       cache: "no-store",
       headers: {
@@ -167,6 +167,35 @@ async function getOrderItemById(orderItemId: string): Promise<OrderItem> {
     }
 }
 
+async function createOrder(order: CreateOrder): Promise<ResponseAPI> {
+    try {
+      const response = await fetch(
+        `${url_api}/api/orders/create-orders`,
+        {
+          method: "POST",
+          cache: "no-store",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(order),
+        }
+      );
+
+      return {
+        status: response.status,
+        message: "Order created successfully",
+        data: [],
+      };
+
+    } catch (error) {
+      return {
+        status: 500,
+        message: "An error occurred while creating the order",
+        data: [],
+      };
+    }
+}
+
 
 
 export function getHandlesAPI() {
@@ -179,6 +208,7 @@ export function getHandlesAPI() {
       getOrderItemById: getOrderItemById,
       getOrderItens: getOrderItens,
       createTable: createTable,
+      createOrder: createOrder,
     };
   }
   

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,6 +37,11 @@ export interface Order {
   quantity: number;
 }
 
+export interface CreateOrder {
+  id_table: string;
+  quantity: number;
+}
+
 
 export interface ResponseAPI {
   status: number;


### PR DESCRIPTION
## Summary
- ensure API uses base URL variable for creating tables
- update `createOrder` to hit `/api/orders/create-orders`

## Testing
- `npm run typecheck` *(fails: Cannot find module)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845edcd656883259ed5b92a3494dce3