### PR TITLE
Hook table section button to API

### DIFF
--- a/src/components/tables/TableCard.tsx
+++ b/src/components/tables/TableCard.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -5,6 +7,9 @@ import type { Table } from '@/lib/types';
 import { Armchair, CheckCircle, Clock, MapPin, Users, XCircle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { getHandlesAPI } from '@/lib/api';
+import { useState } from 'react';
+import { toast } from '@/hooks/use-toast';
 
 interface TableCardProps {
   table: Table;
@@ -24,6 +29,27 @@ const statusIcons = {
 
 
 export function TableCard({ table }: TableCardProps) {
+  const { createSection } = getHandlesAPI();
+  const [loading, setLoading] = useState(false);
+
+  const handleOpenSection = async () => {
+    setLoading(true);
+    const resp = await createSection(table.id_table);
+    if (resp.status >= 200 && resp.status < 300) {
+      toast({
+        title: "Seção aberta",
+        description: `Mesa ${table.table_number} em uso`,
+      });
+      window.location.reload();
+    } else {
+      toast({
+        title: "Erro ao abrir",
+        description: "Não foi possível abrir a seção",
+      });
+    }
+    setLoading(false);
+  };
+
   return (
     <Card className="flex flex-col h-full shadow-lg hover:shadow-xl transition-shadow duration-300 rounded-lg overflow-hidden">
       <CardHeader className="pb-3">
@@ -45,12 +71,13 @@ export function TableCard({ table }: TableCardProps) {
           </Badge>
           <div className="flex items-center">
               {table.status === 'Livre' && 
-              <Button 
-              variant="ghost" 
+              <Button
+              variant="ghost"
               className="py-0 items-start border-green-500 bg-green-100 text-green-700"
-              onClick={() => console.log('Open section for table')}
+              onClick={handleOpenSection}
+              disabled={loading}
               >
-                Abrir Seção
+                {loading ? 'Abrindo...' : 'Abrir Seção'}
               </Button>
               }
           </div>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -238,6 +238,7 @@ export function getHandlesAPI() {
       getOrderItens: getOrderItens,
       createTable: createTable,
       createOrder: createOrder,
+      createSection: createSection,
     };
   }
   


### PR DESCRIPTION
## Summary
- make TableCard a client component and connect the *Abrir Seção* button with the `createSection` API
- export `createSection` through `getHandlesAPI`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f5f82dbf48325a248d5c682f7f2f1